### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
+# For Sinatra configuration, defaults to production. 
+# For local development, set this value to development
+APP_ENV=production
+
 # Twilio API credentials
 # Found at https://www.twilio.com/user/account/settings
-export TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXX
-export TWILIO_AUTH_TOKEN=your-token
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your-token
 
 # Twilio phone number
 # Purchase one at https://www.twilio.com/user/account/phone-numbers
-export TWILIO_NUMBER=+15551234567
+TWILIO_NUMBER=+15551234567

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
   
 .rvmrc
 .env
+/vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # A sample Gemfile
 source 'https://rubygems.org'
 
+gem 'dotenv'
 gem 'sinatra'
 gem 'rspec'
 gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
       dm-core (~> 1.2.0)
     do_postgres (0.10.17)
       data_objects (= 0.10.17)
+    dotenv (2.7.6)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
@@ -105,6 +106,7 @@ PLATFORMS
 DEPENDENCIES
   data_mapper
   dm-postgres-adapter
+  dotenv
   json
   pg
   rack-contrib
@@ -115,4 +117,4 @@ DEPENDENCIES
   twilio-ruby (>= 5.0.0)
 
 BUNDLED WITH
-   1.15.1
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use Twilio to create SMS notifications to keep your subscribers in the loop.
 
 [Read the full tutorial here](https://www.twilio.com/docs/tutorials/walkthrough/marketing-notifications/ruby/sinatra)!
 
-## Local development
+## Get started
 
 This project is built using [Sinatra](http://www.sinatrarb.com/) Framework.
 
@@ -31,8 +31,6 @@ This project is built using [Sinatra](http://www.sinatrarb.com/) Framework.
 1. Copy the `.env.example` file to `.env`, and edit it including your credentials
    for the Twilio API (found at https://www.twilio.com/console/account/settings).
    You will also need a [Twilio Number](https://www.twilio.com/console/phone-numbers/incoming).
-
-   Run `source .env` to export the environment variables.
 
 1. Create application database.
 
@@ -74,6 +72,14 @@ This project is built using [Sinatra](http://www.sinatrarb.com/) Framework.
    ![Request URL](http://howtodocs.s3.amazonaws.com/setup-twilio-number.png)
 
 1. Check it out at [`http://localhost:4567`](http://localhost:4567).
+
+### Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).
 
 ## Meta
 

--- a/app.rb
+++ b/app.rb
@@ -1,9 +1,18 @@
+require 'dotenv'
 require 'sinatra'
 require 'data_mapper'
 require 'json'
 require 'rack/contrib'
 require 'tilt/erb'
 require_relative 'model/subscriber'
+
+# Load environment configuration
+Dotenv.load
+
+# Set the environment after dotenv loads
+# Default to production
+environment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, environment
 
 database_url = 'postgres://postgres:postgres@localhost/marketing_notifications'
 DataMapper.setup(:default, database_url)


### PR DESCRIPTION
Set default environment to production.

Changes in the PR:

- Set `APP_ENV` to `production`
- Install dotenv
- Update README.
